### PR TITLE
docker-machine wrapper script

### DIFF
--- a/bash/dockermachine.bash
+++ b/bash/dockermachine.bash
@@ -44,7 +44,7 @@ function dmachine() {
 
       dmachine "${MACHINENAME}" "" "${QUIET}"
     else
-      [ -z "${QUIET}" ] && echo "dmachine: ${MACHINENAME} does not exist." >&2
+      [ -z "${QUIET}" ] && echo "dmachine: ${MACHINENAME} is not started or does not exist." >&2
       return 1
     fi
   fi

--- a/bash/dockermachine.bash
+++ b/bash/dockermachine.bash
@@ -20,7 +20,8 @@ function dmachine() {
 
     [ -z "${QUIET}" ] && echo "dmachine: adding /etc/hosts entry ${ETCHOSTNAME} -> ${MACHINEIP}"
 
-    sudo add-etc-host "${ETCHOSTNAME}" "${MACHINEIP}"
+    add-etc-host "${ETCHOSTNAME}" "${MACHINEIP}"
+    [ "$?" = "2" ] && sudo add-etc-host "${ETCHOSTNAME}" "${MACHINEIP}"
   else
     if [ -n "${CREATE}" ]; then
       local STATUS="$(docker-machine status ${MACHINENAME} 2>/dev/null)"

--- a/bash/dockermachine.bash
+++ b/bash/dockermachine.bash
@@ -55,7 +55,7 @@ function machineme() {
   ORIGINAL_CONFIG=$(readlink ${HOME}/.ssh/config)
   setup-offvpn 1>/dev/null
 
-  eval "$(docker-machine env dev)"
+  dmachine dev "" quiet
 
   ln -f -s ${ORIGINAL_CONFIG} ${HOME}/.ssh/config
 }

--- a/bash/dockermachine.bash
+++ b/bash/dockermachine.bash
@@ -1,5 +1,10 @@
 # Automatically shellinit docker-machine if it's up.
 
+# Use a named docker-machine VirtualBox VM, optionally creating or starting it if necessary.
+# Automatically source the connection environment variables into the current shell and add or
+# modify /etc/hosts to include an entry pointing to it.
+#
+# Usage: dmachine <machine-name> [create] [quiet]
 function dmachine() {
   local MACHINENAME=$1
   local CREATE=${2:-}

--- a/bash/dockermachine.bash
+++ b/bash/dockermachine.bash
@@ -18,10 +18,11 @@ function dmachine() {
     local ETCHOSTNAME="docker${MACHINENAME}"
     local MACHINEIP=$(docker-machine ip ${MACHINENAME})
 
-    [ -z "${QUIET}" ] && echo "dmachine: adding /etc/hosts entry ${ETCHOSTNAME} -> ${MACHINEIP}"
-
     add-etc-host "${ETCHOSTNAME}" "${MACHINEIP}"
-    [ "$?" = "2" ] && sudo add-etc-host "${ETCHOSTNAME}" "${MACHINEIP}"
+    [ "$?" = "2" ] && {
+      echo "dmachine: adding /etc/hosts entry ${ETCHOSTNAME} -> ${MACHINEIP}"
+      sudo add-etc-host "${ETCHOSTNAME}" "${MACHINEIP}"
+    }
   else
     if [ -n "${CREATE}" ]; then
       local STATUS="$(docker-machine status ${MACHINENAME} 2>/dev/null)"

--- a/bin/add-etc-host
+++ b/bin/add-etc-host
@@ -11,14 +11,9 @@ if hostname.nil? or hostip.nil?
   exit 1
 end
 
-unless File.writable?("/etc/hosts")
-  $stderr.puts "#{$0} must be run sudo."
-  exit 1
-end
-
 lines = File.readlines("/etc/hosts", encoding: "utf-8")
 pattern = /^ *(?:[0-9]+\.){3}[0-9]+ +#{hostname}/
-entry = "#{hostip} #{hostname}"
+entry = "#{hostip} #{hostname}\n"
 found = false
 
 modified = lines.map do |line|
@@ -32,4 +27,11 @@ end
 
 modified << entry unless found
 
-File.write("/etc/hosts", modified.join, encoding: "utf-8")
+if modified.join != lines.join
+  if File.writable?("/etc/hosts")
+    File.write("/etc/hosts", modified.join, encoding: "utf-8")
+  else
+    # Modification needed
+    exit 2
+  end
+end

--- a/bin/add-etc-host
+++ b/bin/add-etc-host
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+hostname = ARGV[0]
+hostip = ARGV[1]
+
+if hostname.nil? or hostip.nil?
+  $stderr.puts "Usage: #{$0} <hostname> <hostip>"
+  $stderr.puts ""
+  $stderr.puts " Add or modify an /etc/hosts entry for <hostname> to point to <hostip>."
+  $stderr.puts " Must be run sudo."
+  exit 1
+end
+
+unless File.writable?("/etc/hosts")
+  $stderr.puts "#{$0} must be run sudo."
+  exit 1
+end
+
+lines = File.readlines("/etc/hosts", encoding: "utf-8")
+pattern = /^ *(?:[0-9]+\.){3}[0-9]+ +#{hostname}/
+entry = "#{hostip} #{hostname}"
+found = false
+
+modified = lines.map do |line|
+  if line =~ pattern
+    found = true
+    entry
+  else
+    line
+  end
+end
+
+modified << entry unless found
+
+File.write("/etc/hosts", modified.join, encoding: "utf-8")

--- a/bin/quote
+++ b/bin/quote
@@ -1,1 +1,0 @@
-ssh -t azurefire.net 'sudo vim /var/pushbot/botdata/quotes'

--- a/bin/quote-commit
+++ b/bin/quote-commit
@@ -1,1 +1,0 @@
-ssh -t azurefire.net 'sudo su - pushbot -c "cd /var/pushbot/botdata/ && git add . && git commit"'


### PR DESCRIPTION
Managing `docker-machine` VMs manually can be a bit of a pain. I'm writing a wrapper script that:
- Automatically does the `eval "$(docker-machine env blah)"` bit.
- Will optionally start or create a VM on demand.
- Adds or updates an `/etc/hosts` entry pointing to the VM.
